### PR TITLE
Convert colorSettins attribute in ImageData interface to a getter method

### DIFF
--- a/CanvasColorSpaceProposal.md
+++ b/CanvasColorSpaceProposal.md
@@ -159,7 +159,8 @@ interface ImageData {
   readonly attribute unsigned long width;
   readonly attribute unsigned long height;
   readonly attribute ImageDataArray data;
-  readonly attribute ImageDataColorSettings colorAttributes;
+  
+  ImageDataColorSettings getColorSettings();
 };
 </pre>
 


### PR DESCRIPTION
ImageDataColorSettings is a dictionary, so it must not be used as the type of an attribute. This pull request fixes this by converting the colorSettings attribute in ImageData interface to a getter method.